### PR TITLE
Fix: yes no case sensitivity

### DIFF
--- a/src/Data/Gedcom/Internal/Parser.hs
+++ b/src/Data/Gedcom/Internal/Parser.hs
@@ -1016,7 +1016,7 @@ parseBoolTag tag = parseNoLinkTag tag$ \(v, _) ->
     Just yn -> return yn
   where
     ynParser :: Parser Bool
-    ynParser = (True <$ "yes") <|> (False <$ "no")
+    ynParser = (True <$ string' "yes") <|> (False <$ string' "no")
 
 -- | Parse a Word value.
 parseWordTag :: GDTag -> StructureParser Word


### PR DESCRIPTION
Hello,

When runnin `stack test` in my environment, I runned into a failing test :

```
  test\Spec.hs:143:
  1) parseBoolTag parses case insensitive
       expected: Match True
        but got: Error "FormatError \"Expected boolean, saw [(Nothing,\\\"Yes\\\")]\""
```
Here is the fix.

Thank you
