### PR TITLE
Fix: markdown links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gedcom
 
 A parser for the GEDCOM genealogy file format.  More information on
-[https://en.wikipedia.org/wiki/GEDCOM](Wikipedia).  The full specification is
-[https://www.familysearch.org/developers/docs/gedcom/](here).
+[Wikipedia](https://en.wikipedia.org/wiki/GEDCOM).  The full specification is
+[here](https://www.familysearch.org/developers/docs/gedcom/).
 


### PR DESCRIPTION
Hello,

The text and target of links were switched.

thanks